### PR TITLE
Add Eclipse Foundation cookie consent to template

### DIFF
--- a/src/partials/head-scripts.hbs
+++ b/src/partials/head-scripts.hbs
@@ -7,4 +7,6 @@
         if (theme === 'dark') document.documentElement.classList.add('theme-dark')
       }(localStorage && localStorage.getItem('theme') || (matchMedia('(prefers-color-scheme: dark)') && 'dark'))
     </script>
+    <!-- Add Eclipse Foundation cookie consent to site for GA -->
+    <script src="//www.eclipse.org/eclipse.org-common/themes/solstice/public/javascript/vendor/cookieconsent/default.min.js"></script>
     

--- a/src/partials/head-styles.hbs
+++ b/src/partials/head-styles.hbs
@@ -1,1 +1,2 @@
     <link rel="stylesheet" href="{{{uiRootPath}}}/css/site.css">
+    <link rel="stylesheet" type="text/css" href="//www.eclipse.org/eclipse.org-common/themes/solstice/public/stylesheets/vendor/cookieconsent/cookieconsent.min.css" />


### PR DESCRIPTION
As requested in https://github.com/jakartaee/jakartaee-documentation/issues/20, a cookie consent banner will be added to the core template of the site in compliance with privacy laws in enabling Google Analytics.